### PR TITLE
Add login page with cloud login

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,12 +12,14 @@ App({
       logs.unshift(Date.now())
       wx.setStorageSync('logs', logs)
   
-      // 登录
-      wx.login({
-        success: res => {
-          // 发送 res.code 到后台换取 openId, sessionKey, unionId
-        }
-      })
+      // 登录并获取 openid
+      wx.cloud.callFunction({ name: 'login' })
+        .then(res => {
+          wx.setStorageSync('openid', res.result.openid);
+        })
+        .catch(err => {
+          console.error('获取 openid 失败', err);
+        });
     },
     globalData: {
       userInfo: null

--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
     "pages": [
+      "pages/login/login",
       "pages/index/index",
       "pages/orders/orders",
       "pages/admin/admin",

--- a/pages/login/login.js
+++ b/pages/login/login.js
@@ -1,0 +1,19 @@
+Page({
+  onLoad() {
+    const openid = wx.getStorageSync('openid');
+    if (openid) {
+      wx.redirectTo({ url: '/pages/index/index' });
+    }
+  },
+  doLogin() {
+    wx.cloud.callFunction({ name: 'login' })
+      .then(res => {
+        wx.setStorageSync('openid', res.result.openid);
+        wx.redirectTo({ url: '/pages/index/index' });
+      })
+      .catch(err => {
+        console.error('登录失败', err);
+        wx.showToast({ title: '登录失败', icon: 'none' });
+      });
+  }
+});

--- a/pages/login/login.json
+++ b/pages/login/login.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "登录"
+}

--- a/pages/login/login.wxml
+++ b/pages/login/login.wxml
@@ -1,0 +1,3 @@
+<view class="container">
+  <button type="primary" bindtap="doLogin">登录</button>
+</view>

--- a/pages/login/login.wxss
+++ b/pages/login/login.wxss
@@ -1,0 +1,6 @@
+.container {
+  display: flex;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- implement cloud login call in `app.js`
- add new login page with button
- set login page as first page in `app.json`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68463fecd604832dadf60f42406b5cd2